### PR TITLE
Modifications to IPAAnsibleModule.

### DIFF
--- a/plugins/modules/ipaautomountlocation.py
+++ b/plugins/modules/ipaautomountlocation.py
@@ -33,13 +33,9 @@ author: chris procter
 short_description: Manage FreeIPA autommount locations
 description:
 - Add and delete an IPA automount location
+extends_documentation_fragment:
+  - ipamodule_base_docs
 options:
-  ipaadmin_principal:
-    description: The admin principal
-    default: admin
-  ipaadmin_password:
-    description: The admin password
-    required: false
   name:
     description: The automount location to be managed
     required: true
@@ -79,9 +75,9 @@ class AutomountLocation(FreeIPABaseModule):
 
     def get_location(self, location):
         try:
-            response = self.api_command("automountlocation_show",
-                                        location,
-                                        {})
+            response = self.ipa_command(
+                "automountlocation_show", location, {}
+            )
         except ipalib_errors.NotFound:
             return None
         else:

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -31,13 +31,9 @@ DOCUMENTATION = """
 module: ipadnszone
 short description: Manage FreeIPA dnszone
 description: Manage FreeIPA dnszone
+extends_documentation_fragment:
+  - ipamodule_base_docs
 options:
-  ipaadmin_principal:
-    description: The admin principal
-    default: admin
-  ipaadmin_password:
-    description: The admin password
-    required: false
   name:
     description: The zone name string.
     required: true
@@ -408,7 +404,9 @@ class DNSZoneModule(FreeIPABaseModule):
         get_zone_args = {"idnsname": zone_name, "all": True}
 
         try:
-            response = self.api_command("dnszone_show", args=get_zone_args)
+            response = self.ipa_command_no_name(
+                "dnszone_show", args=get_zone_args
+            )
         except ipalib_errors.NotFound:
             zone = None
             is_zone_active = False


### PR DESCRIPTION
This PR modifies IPAAnsibleModule by:
* removing usage of `self` in methods not requiring it, turning
   the methods into @statimethod; 
* adding comments to all the methods in IPAAnsibleModule, which
    makes it easier to understand what the individual methods do,
    and what their parameters represent.

It also modifies `dnszone` and `automountlocation` to use the new
document fragment and commonly defined ipaadmin_* variables.