### PR TITLE
New ipa ansible module

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -753,6 +753,72 @@ else:
             """
             return api_check_ipa_version(oper, requested_version)
 
+        def execute_ipa_commands(self, commands, handle_result=None,
+                                 **handle_result_user_args):
+            """
+            Execute IPA API commands from command list.
+
+            Parameters
+            ----------
+            commands: list of string tuple
+                The list of commands in the form (name, command and args)
+                For commands that do not require a 'name', None needs be
+                used.
+            handle_result: function
+                The user function to handle results of the single commands
+            handle_result_user_args: dict (user args mapping)
+                The user args to pass to handle_result function
+
+            Example (ipauser module):
+
+            def handle_result(result, command, name, args, exit_args):
+                if "random" in args and command in ["user_add", "user_mod"] \
+                   and "randompassword" in result["result"]:
+                    exit_args.setdefault(name, {})["randompassword"] = \
+                        result["result"]["randompassword"]
+
+            exit_args = {}
+            changed = module.execute_ipa_commands(commands, handle_result,
+                                                  exit_args=exit_args)
+
+            if len(names) == 1:
+                ansible_module.exit_json(changed=changed,
+                                         user=exit_args[names[0]])
+            else:
+                ansible_module.exit_json(changed=changed, user=exit_args)
+
+            """
+            # No commands, report no changes
+            if commands is None:
+                return False
+
+            # In check_mode return if there are commands to do
+            if self.check_mode:
+                return len(commands) > 0
+
+            changed = False
+            for name, command, args in commands:
+                try:
+                    if name is None:
+                        result = self.ipa_command_no_name(command, args)
+                    else:
+                        result = self.ipa_command(command, name, args)
+
+                    if "completed" in result:
+                        if result["completed"] > 0:
+                            changed = True
+                    else:
+                        changed = True
+
+                    if handle_result is not None:
+                        handle_result(result, command, name, args,
+                                      **handle_result_user_args)
+
+                except Exception as e:
+                    self.fail_json(msg="%s: %s: %s" % (command, name, str(e)))
+
+            return changed
+
     class FreeIPABaseModule(IPAAnsibleModule):
         """
         Base class for FreeIPA Ansible modules.

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -621,6 +621,8 @@ else:
             # pylint: disable=super-with-arguments
             super(IPAAnsibleModule, self).__init__(*args, **kwargs)
 
+            self._ansible_debug = True
+
             # ipaadmin vars
             self.ipaadmin_principal = self.params_get("ipaadmin_principal")
             self.ipaadmin_password = self.params_get("ipaadmin_password")

--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -220,8 +220,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipaautomountlocation.py
+++ b/plugins/modules/ipaautomountlocation.py
@@ -33,13 +33,9 @@ author: chris procter
 short_description: Manage FreeIPA autommount locations
 description:
 - Add and delete an IPA automount location
+extends_documentation_fragment:
+  - ipamodule_base_docs
 options:
-  ipaadmin_principal:
-    description: The admin principal
-    default: admin
-  ipaadmin_password:
-    description: The admin password
-    required: false
   name:
     description: The automount location to be managed
     required: true
@@ -79,9 +75,9 @@ class AutomountLocation(FreeIPABaseModule):
 
     def get_location(self, location):
         try:
-            response = self.api_command("automountlocation_show",
-                                        location,
-                                        {})
+            response = self.ipa_command(
+                "automountlocation_show", location, {}
+            )
         except ipalib_errors.NotFound:
             return None
         else:

--- a/plugins/modules/ipaconfig.py
+++ b/plugins/modules/ipaconfig.py
@@ -311,8 +311,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     field_map = {

--- a/plugins/modules/ipadelegation.py
+++ b/plugins/modules/ipadelegation.py
@@ -158,8 +158,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipadnsconfig.py
+++ b/plugins/modules/ipadnsconfig.py
@@ -182,8 +182,6 @@ def main():
        )
     )
 
-    ansible_module._ansible_debug = True
-
     # dnsconfig
     forwarders = ansible_module.params_get('forwarders') or []
     forward_policy = ansible_module.params_get('forward_policy')

--- a/plugins/modules/ipadnsforwardzone.py
+++ b/plugins/modules/ipadnsforwardzone.py
@@ -188,8 +188,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
     names = ansible_module.params_get("name")
     action = ansible_module.params_get("action")

--- a/plugins/modules/ipadnsrecord.py
+++ b/plugins/modules/ipadnsrecord.py
@@ -1126,8 +1126,6 @@ def configure_module():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     return ansible_module
 
 

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -31,13 +31,9 @@ DOCUMENTATION = """
 module: ipadnszone
 short description: Manage FreeIPA dnszone
 description: Manage FreeIPA dnszone
+extends_documentation_fragment:
+  - ipamodule_base_docs
 options:
-  ipaadmin_principal:
-    description: The admin principal
-    default: admin
-  ipaadmin_password:
-    description: The admin password
-    required: false
   name:
     description: The zone name string.
     required: true
@@ -408,7 +404,9 @@ class DNSZoneModule(FreeIPABaseModule):
         get_zone_args = {"idnsname": zone_name, "all": True}
 
         try:
-            response = self.api_command("dnszone_show", args=get_zone_args)
+            response = self.ipa_command_no_name(
+                "dnszone_show", args=get_zone_args
+            )
         except ipalib_errors.NotFound:
             zone = None
             is_zone_active = False

--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -305,8 +305,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -31,13 +31,9 @@ DOCUMENTATION = """
 module: ipagroup
 short description: Manage FreeIPA groups
 description: Manage FreeIPA groups
+extends_documentation_fragment:
+  - ipamodule_base_docs
 options:
-  ipaadmin_principal:
-    description: The admin principal
-    default: admin
-  ipaadmin_password:
-    description: The admin password
-    required: false
   name:
     description: The group name
     required: false
@@ -182,10 +178,8 @@ EXAMPLES = """
 RETURN = """
 """
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
-    temp_kdestroy, valid_creds, api_connect, api_command, compare_args_ipa, \
-    api_check_param, module_params_get, gen_add_del_lists, api_check_command, \
+from ansible.module_utils.ansible_freeipa_module import \
+    IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, \
     gen_add_list, gen_intersection_list
 
 
@@ -195,7 +189,7 @@ def find_group(module, name):
         "cn": name,
     }
 
-    _result = api_command(module, "group_find", name, _args)
+    _result = module.ipa_command("group_find", name, _args)
 
     if len(_result["result"]) > 1:
         module.fail_json(
@@ -278,12 +272,9 @@ def should_modify_group(module, res_find, args, nonposix, posix, external):
 
 
 def main():
-    ansible_module = AnsibleModule(
+    ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # general
-            ipaadmin_principal=dict(type="str", default="admin"),
-            ipaadmin_password=dict(type="str", required=False, no_log=True),
-
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -319,31 +310,24 @@ def main():
     # Get parameters
 
     # general
-    ipaadmin_principal = module_params_get(
-        ansible_module,
-        "ipaadmin_principal",
-    )
-    ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
-    names = module_params_get(ansible_module, "name")
+    names = ansible_module.params_get("name")
 
     # present
-    description = module_params_get(ansible_module, "description")
-    gid = module_params_get(ansible_module, "gid")
-    nonposix = module_params_get(ansible_module, "nonposix")
-    external = module_params_get(ansible_module, "external")
-    posix = module_params_get(ansible_module, "posix")
-    nomembers = module_params_get(ansible_module, "nomembers")
-    user = module_params_get(ansible_module, "user")
-    group = module_params_get(ansible_module, "group")
-    service = module_params_get(ansible_module, "service")
-    membermanager_user = module_params_get(ansible_module,
-                                           "membermanager_user")
-    membermanager_group = module_params_get(ansible_module,
-                                            "membermanager_group")
-    externalmember = module_params_get(ansible_module, "externalmember")
-    action = module_params_get(ansible_module, "action")
+    description = ansible_module.params_get("description")
+    gid = ansible_module.params_get("gid")
+    nonposix = ansible_module.params_get("nonposix")
+    external = ansible_module.params_get("external")
+    posix = ansible_module.params_get("posix")
+    nomembers = ansible_module.params_get("nomembers")
+    user = ansible_module.params_get("user")
+    group = ansible_module.params_get("group")
+    service = ansible_module.params_get("service")
+    membermanager_user = ansible_module.params_get("membermanager_user")
+    membermanager_group = ansible_module.params_get("membermanager_group")
+    externalmember = ansible_module.params_get("externalmember")
+    action = ansible_module.params_get("action")
     # state
-    state = module_params_get(ansible_module, "state")
+    state = ansible_module.params_get("state")
 
     # Check parameters
 
@@ -378,21 +362,19 @@ def main():
 
     changed = False
     exit_args = {}
-    ccache_dir = None
-    ccache_name = None
-    try:
-        if not valid_creds(ansible_module, ipaadmin_principal):
-            ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
-                                                 ipaadmin_password)
-        api_connect()
 
-        has_add_member_service = api_check_param("group_add_member", "service")
+    # Connect to IPA API
+    with ansible_module.ipa_connect():
+
+        has_add_member_service = ansible_module.ipa_command_param_exists(
+            "group_add_member", "service")
         if service is not None and not has_add_member_service:
             ansible_module.fail_json(
                 msg="Managing a service as part of a group is not supported "
                 "by your IPA version")
 
-        has_add_membermanager = api_check_command("group_add_member_manager")
+        has_add_membermanager = ansible_module.ipa_command_exists(
+            "group_add_member_manager")
         if ((membermanager_user is not None or
              membermanager_group is not None) and not has_add_membermanager):
             ansible_module.fail_json(
@@ -684,8 +666,7 @@ def main():
 
         for name, command, args in commands:
             try:
-                result = api_command(ansible_module, command, name,
-                                     args)
+                result = ansible_module.ipa_command(command, name, args)
                 if "completed" in result:
                     if result["completed"] > 0:
                         changed = True
@@ -705,12 +686,6 @@ def main():
                             command, member_type, member, failure))
             if len(errors) > 0:
                 ansible_module.fail_json(msg=", ".join(errors))
-
-    except Exception as e:
-        ansible_module.fail_json(msg=str(e))
-
-    finally:
-        temp_kdestroy(ccache_dir, ccache_name)
 
     # Done
 

--- a/plugins/modules/ipahbacrule.py
+++ b/plugins/modules/ipahbacrule.py
@@ -222,8 +222,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipahbacrule.py
+++ b/plugins/modules/ipahbacrule.py
@@ -31,13 +31,9 @@ DOCUMENTATION = """
 module: ipahbacrule
 short description: Manage FreeIPA HBAC rules
 description: Manage FreeIPA HBAC rules
+extends_documentation_fragment:
+  - ipamodule_base_docs
 options:
-  ipaadmin_principal:
-    description: The admin principal
-    default: admin
-  ipaadmin_password:
-    description: The admin password
-    required: false
   name:
     description: The hbacrule name
     required: true
@@ -156,11 +152,9 @@ EXAMPLES = """
 RETURN = """
 """
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
-    temp_kdestroy, valid_creds, api_connect, api_command, compare_args_ipa, \
-    module_params_get, gen_add_del_lists, gen_add_list, \
-    gen_intersection_list, api_get_domain, ensure_fqdn
+from ansible.module_utils.ansible_freeipa_module import \
+    IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
+    gen_intersection_list, ensure_fqdn
 
 
 def find_hbacrule(module, name):
@@ -169,7 +163,7 @@ def find_hbacrule(module, name):
         "cn": name,
     }
 
-    _result = api_command(module, "hbacrule_find", name, _args)
+    _result = module.ipa_command("hbacrule_find", name, _args)
 
     if len(_result["result"]) > 1:
         module.fail_json(
@@ -198,12 +192,9 @@ def gen_args(description, usercategory, hostcategory, servicecategory,
 
 
 def main():
-    ansible_module = AnsibleModule(
+    ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # general
-            ipaadmin_principal=dict(type="str", default="admin"),
-            ipaadmin_password=dict(type="str", required=False, no_log=True),
-
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -236,26 +227,23 @@ def main():
     # Get parameters
 
     # general
-    ipaadmin_principal = module_params_get(ansible_module,
-                                           "ipaadmin_principal")
-    ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
-    names = module_params_get(ansible_module, "name")
+    names = ansible_module.params_get("name")
 
     # present
-    description = module_params_get(ansible_module, "description")
-    usercategory = module_params_get(ansible_module, "usercategory")
-    hostcategory = module_params_get(ansible_module, "hostcategory")
-    servicecategory = module_params_get(ansible_module, "servicecategory")
-    nomembers = module_params_get(ansible_module, "nomembers")
-    host = module_params_get(ansible_module, "host")
-    hostgroup = module_params_get(ansible_module, "hostgroup")
-    hbacsvc = module_params_get(ansible_module, "hbacsvc")
-    hbacsvcgroup = module_params_get(ansible_module, "hbacsvcgroup")
-    user = module_params_get(ansible_module, "user")
-    group = module_params_get(ansible_module, "group")
-    action = module_params_get(ansible_module, "action")
+    description = ansible_module.params_get("description")
+    usercategory = ansible_module.params_get("usercategory")
+    hostcategory = ansible_module.params_get("hostcategory")
+    servicecategory = ansible_module.params_get("servicecategory")
+    nomembers = ansible_module.params_get("nomembers")
+    host = ansible_module.params_get("host")
+    hostgroup = ansible_module.params_get("hostgroup")
+    hbacsvc = ansible_module.params_get("hbacsvc")
+    hbacsvcgroup = ansible_module.params_get("hbacsvcgroup")
+    user = ansible_module.params_get("user")
+    group = ansible_module.params_get("group")
+    action = ansible_module.params_get("action")
     # state
-    state = module_params_get(ansible_module, "state")
+    state = ansible_module.params_get("state")
 
     # Check parameters
 
@@ -318,16 +306,12 @@ def main():
 
     changed = False
     exit_args = {}
-    ccache_dir = None
-    ccache_name = None
-    try:
-        if not valid_creds(ansible_module, ipaadmin_principal):
-            ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
-                                                 ipaadmin_password)
-        api_connect()
+
+    # Connect to IPA API
+    with ansible_module.ipa_connect():
 
         # Get default domain
-        default_domain = api_get_domain()
+        default_domain = ansible_module.ipa_get_domain()
 
         # Ensure fqdn host names, use default domain for simple names
         if host is not None:
@@ -620,8 +604,7 @@ def main():
         errors = []
         for name, command, args in commands:
             try:
-                result = api_command(ansible_module, command, name,
-                                     args)
+                result = ansible_module.ipa_command(command, name, args)
                 if "completed" in result:
                     if result["completed"] > 0:
                         changed = True
@@ -641,12 +624,6 @@ def main():
                                 command, member_type, member, failure))
         if len(errors) > 0:
             ansible_module.fail_json(msg=", ".join(errors))
-
-    except Exception as e:
-        ansible_module.fail_json(msg=str(e))
-
-    finally:
-        temp_kdestroy(ccache_dir, ccache_name)
 
     # Done
 

--- a/plugins/modules/ipahbacsvc.py
+++ b/plugins/modules/ipahbacsvc.py
@@ -112,8 +112,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipahbacsvcgroup.py
+++ b/plugins/modules/ipahbacsvcgroup.py
@@ -155,8 +155,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -687,8 +687,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipahostgroup.py
+++ b/plugins/modules/ipahostgroup.py
@@ -203,8 +203,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipalocation.py
+++ b/plugins/modules/ipalocation.py
@@ -102,8 +102,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipapermission.py
+++ b/plugins/modules/ipapermission.py
@@ -225,8 +225,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipaprivilege.py
+++ b/plugins/modules/ipaprivilege.py
@@ -146,8 +146,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipapwpolicy.py
+++ b/plugins/modules/ipapwpolicy.py
@@ -188,8 +188,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -428,8 +428,6 @@ def create_module():
         required_one_of=[]
     )
 
-    ansible_module._ansible_debug = True  # pylint: disable=protected-access
-
     return ansible_module
 
 

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -33,13 +33,9 @@ DOCUMENTATION = """
 module: iparole
 short description: Manage FreeIPA role
 description: Manage FreeIPA role
+extends_documentation_fragment:
+  - ipamodule_base_docs
 options:
-  ipaadmin_principal:
-    description: The admin principal.
-    default: admin
-  ipaadmin_password:
-    description: The admin password.
-    required: false
   role:
     description: The list of role name strings.
     required: true
@@ -101,11 +97,9 @@ EXAMPLES = """
 # pylint: disable=wrong-import-position
 # pylint: disable=import-error
 # pylint: disable=no-name-in-module
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import \
-    temp_kinit, temp_kdestroy, valid_creds, api_connect, api_command, \
-    gen_add_del_lists, compare_args_ipa, module_params_get, api_get_realm
+    IPAAnsibleModule, gen_add_del_lists, compare_args_ipa
 import six
 
 
@@ -116,7 +110,7 @@ if six.PY3:
 def find_role(module, name):
     """Find if a role with the given name already exist."""
     try:
-        _result = api_command(module, "role_show", name, {"all": True})
+        _result = module.ipa_command("role_show", name, {"all": True})
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if role name is not found.
         return None
@@ -133,7 +127,7 @@ def gen_args(module):
     args = {}
 
     for param, arg in arg_map.items():
-        value = module_params_get(module, param)
+        value = module.params_get(param)
         if value is not None:
             args[arg] = value
 
@@ -142,8 +136,8 @@ def gen_args(module):
 
 def check_parameters(module):
     """Check if parameters passed for module processing are valid."""
-    action = module_params_get(module, "action")
-    state = module_params_get(module, "state")
+    action = module.params_get("action")
+    state = module.params_get("state")
 
     invalid = []
 
@@ -157,30 +151,15 @@ def check_parameters(module):
             invalid.extend(['privilege'])
 
     for arg in invalid:
-        if module_params_get(module, arg) is not None:
+        if module.params_get(arg) is not None:
             module.fail_json(
                 msg="Argument '%s' can not be used with action '%s'" %
                 (arg, state))
 
 
-def verify_credentials(module):
-    """Ensure there are valid Kerberos credentials."""
-    ccache_dir = None
-    ccache_name = None
-
-    ipaadmin_principal = module_params_get(module, "ipaadmin_principal")
-    ipaadmin_password = module_params_get(module, "ipaadmin_password")
-
-    if not valid_creds(module, ipaadmin_principal):
-        ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
-                                             ipaadmin_password)
-
-    return (ccache_dir, ccache_name)
-
-
 def member_intersect(module, attr, memberof, res_find):
     """Filter member arguments from role found by intersection."""
-    params = module_params_get(module, attr)
+    params = module.params_get(attr)
     if not res_find:
         return params
     filtered = []
@@ -192,7 +171,7 @@ def member_intersect(module, attr, memberof, res_find):
 
 def member_difference(module, attr, memberof, res_find):
     """Filter member arguments from role found by difference."""
-    params = module_params_get(module, attr)
+    params = module.params_get(attr)
     if not res_find:
         return params
     filtered = []
@@ -247,7 +226,7 @@ def filter_service(module, res_find, predicate):
     modified service to be compared to.
     """
     _services = []
-    service = module_params_get(module, 'service')
+    service = module.params_get('service')
     if service:
         existing = [to_text(x) for x in res_find.get('member_service', [])]
         for svc in service:
@@ -261,7 +240,7 @@ def ensure_role_with_members_is_present(module, name, res_find, action):
     """Define commands to ensure member are present for action `role`."""
     commands = []
     privilege_add, privilege_del = gen_add_del_lists(
-        module_params_get(module, "privilege"),
+        module.params_get("privilege"),
         res_find.get('memberof_privilege', []))
 
     if privilege_add:
@@ -276,7 +255,7 @@ def ensure_role_with_members_is_present(module, name, res_find, action):
 
     for key in ["user", "group", "host", "hostgroup"]:
         add_list, del_list = gen_add_del_lists(
-            module_params_get(module, key),
+            module.params_get(key),
             res_find.get('member_%s' % key, [])
         )
         if add_list:
@@ -285,8 +264,9 @@ def ensure_role_with_members_is_present(module, name, res_find, action):
             del_members[key] = [to_text(item) for item in del_list]
 
     service = [
-        to_text(svc) if '@' in svc else ('%s@%s' % (svc, api_get_realm()))
-        for svc in (module_params_get(module, 'service') or [])
+        to_text(svc) if '@' in svc else ('%s@%s' % (svc,
+                                                    module.ipa_get_realm()))
+        for svc in (module.params_get('service') or [])
     ]
     existing = [str(svc) for svc in res_find.get('member_service', [])]
     add_list, del_list = gen_add_del_lists(service, existing)
@@ -363,7 +343,7 @@ def process_commands(module, commands):
 
     for name, command, args in commands:
         try:
-            result = api_command(module, command, name, args)
+            result = module.ipa_command(command, name, args)
             if "completed" in result:
                 if result["completed"] > 0:
                     changed = True
@@ -385,7 +365,7 @@ def role_commands_for_name(module, state, action, name):
     """Define commands for the Role module."""
     commands = []
 
-    rename = module_params_get(module, "rename")
+    rename = module.params_get("rename")
 
     res_find = find_role(module, name)
 
@@ -420,12 +400,9 @@ def role_commands_for_name(module, state, action, name):
 
 def create_module():
     """Create module description."""
-    ansible_module = AnsibleModule(
+    ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # generalgroups
-            ipaadmin_principal=dict(type="str", default="admin"),
-            ipaadmin_password=dict(type="str", required=False, no_log=True),
-
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -462,15 +439,13 @@ def main():
     check_parameters(ansible_module)
 
     # Init
-    ccache_dir = None
-    ccache_name = None
-    try:
-        ccache_dir, ccache_name = verify_credentials(ansible_module)
-        api_connect()
 
-        state = module_params_get(ansible_module, "state")
-        action = module_params_get(ansible_module, "action")
-        names = module_params_get(ansible_module, "name")
+    # Connect to IPA API
+    with ansible_module.ipa_connect():
+
+        state = ansible_module.params_get("state")
+        action = ansible_module.params_get("action")
+        names = ansible_module.params_get("name")
         commands = []
 
         for name in names:
@@ -478,12 +453,6 @@ def main():
             commands.extend(cmds)
 
         changed, exit_args = process_commands(ansible_module, commands)
-
-    except Exception as exception:  # pylint: disable=broad-except
-        ansible_module.fail_json(msg=str(exception))
-
-    finally:
-        temp_kdestroy(ccache_dir, ccache_name)
 
     # Done
     ansible_module.exit_json(changed=changed, **exit_args)

--- a/plugins/modules/ipaselfservice.py
+++ b/plugins/modules/ipaselfservice.py
@@ -31,13 +31,9 @@ DOCUMENTATION = """
 module: ipaselfservice
 short description: Manage FreeIPA selfservices
 description: Manage FreeIPA selfservices and selfservice attributes
+extends_documentation_fragment:
+  - ipamodule_base_docs
 options:
-  ipaadmin_principal:
-    description: The admin principal.
-    default: admin
-  ipaadmin_password:
-    description: The admin password.
-    required: false
   name:
     description: The list of selfservice name strings.
     required: true
@@ -103,21 +99,14 @@ RETURN = """
 """
 
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_freeipa_module import \
-    temp_kinit, temp_kdestroy, valid_creds, api_connect, api_command, \
-    compare_args_ipa, module_params_get
-import six
-
-
-if six.PY3:
-    unicode = str
+    IPAAnsibleModule, compare_args_ipa
 
 
 def find_selfservice(module, name):
     """Find if a selfservice with the given name already exist."""
     try:
-        _result = api_command(module, "selfservice_show", name, {"all": True})
+        _result = module.ipa_command("selfservice_show", name, {"all": True})
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if selfservice name is not found.
         return None
@@ -135,12 +124,9 @@ def gen_args(permission, attribute):
 
 
 def main():
-    ansible_module = AnsibleModule(
+    ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # general
-            ipaadmin_principal=dict(type="str", default="admin"),
-            ipaadmin_password=dict(type="str", required=False, no_log=True),
-
             name=dict(type="list", aliases=["aciname"], default=None,
                       required=True),
             # present
@@ -162,17 +148,14 @@ def main():
     # Get parameters
 
     # general
-    ipaadmin_principal = module_params_get(ansible_module,
-                                           "ipaadmin_principal")
-    ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
-    names = module_params_get(ansible_module, "name")
+    names = ansible_module.params_get("name")
 
     # present
-    permission = module_params_get(ansible_module, "permission")
-    attribute = module_params_get(ansible_module, "attribute")
-    action = module_params_get(ansible_module, "action")
+    permission = ansible_module.params_get("permission")
+    attribute = ansible_module.params_get("attribute")
+    action = ansible_module.params_get("action")
     # state
-    state = module_params_get(ansible_module, "state")
+    state = ansible_module.params_get("state")
 
     # Check parameters
 
@@ -219,13 +202,9 @@ def main():
 
     changed = False
     exit_args = {}
-    ccache_dir = None
-    ccache_name = None
-    try:
-        if not valid_creds(ansible_module, ipaadmin_principal):
-            ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
-                                                 ipaadmin_password)
-        api_connect()
+
+    # Connect to IPA API
+    with ansible_module.ipa_connect():
 
         commands = []
         for name in names:
@@ -301,8 +280,7 @@ def main():
 
         for name, command, args in commands:
             try:
-                result = api_command(ansible_module, command, name,
-                                     args)
+                result = ansible_module.ipa_command(command, name, args)
                 if "completed" in result:
                     if result["completed"] > 0:
                         changed = True
@@ -311,12 +289,6 @@ def main():
             except Exception as e:
                 ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
                                                              str(e)))
-
-    except Exception as e:
-        ansible_module.fail_json(msg=str(e))
-
-    finally:
-        temp_kdestroy(ccache_dir, ccache_name)
 
     # Done
 

--- a/plugins/modules/ipaselfservice.py
+++ b/plugins/modules/ipaselfservice.py
@@ -143,8 +143,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipaserver.py
+++ b/plugins/modules/ipaserver.py
@@ -264,8 +264,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -404,8 +404,6 @@ def init_ansible_module():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     return ansible_module
 
 

--- a/plugins/modules/ipasudocmd.py
+++ b/plugins/modules/ipasudocmd.py
@@ -111,8 +111,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipasudocmdgroup.py
+++ b/plugins/modules/ipasudocmdgroup.py
@@ -151,8 +151,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -273,8 +273,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipatopologysegment.py
+++ b/plugins/modules/ipatopologysegment.py
@@ -188,8 +188,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     suffixes = ansible_module.params_get("suffix")

--- a/plugins/modules/ipatopologysuffix.py
+++ b/plugins/modules/ipatopologysuffix.py
@@ -69,8 +69,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     suffix = ansible_module.params_get("suffix")

--- a/plugins/modules/ipatrust.py
+++ b/plugins/modules/ipatrust.py
@@ -207,8 +207,6 @@ def main():
         supports_check_mode=True
     )
 
-    ansible_module._ansible_debug = True
-
     # general
     realm = ansible_module.params_get("realm")
 

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -819,8 +819,6 @@ def main():
         supports_check_mode=True,
     )
 
-    ansible_module._ansible_debug = True
-
     # Get parameters
 
     # general

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -31,13 +31,9 @@ DOCUMENTATION = """
 module: ipavault
 short description: Manage vaults and secret vaults.
 description: Manage vaults and secret vaults. KRA service must be enabled.
+extends_documentation_fragment:
+  - ipamodule_base_docs
 options:
-  ipaadmin_principal:
-    description: The admin principal
-    default: admin
-  ipaadmin_password:
-    description: The admin password
-    required: false
   name:
     description: The vault name
     required: true
@@ -317,10 +313,8 @@ vault:
 
 import os
 from base64 import b64decode
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
-from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
-    temp_kdestroy, valid_creds, api_connect, api_command, \
+from ansible.module_utils.ansible_freeipa_module import IPAAnsibleModule, \
     gen_add_del_lists, compare_args_ipa, module_params_get, exit_raw_json, \
     ipalib_errors
 
@@ -338,7 +332,7 @@ def find_vault(module, name, username, service, shared):
     else:
         _args['shared'] = shared
 
-    _result = api_command(module, "vault_find", name, _args)
+    _result = module.ipa_command("vault_find", name, _args)
 
     if len(_result["result"]) > 1:
         module.fail_json(
@@ -579,7 +573,7 @@ def get_stored_data(module, res_find, args):
 
     # retrieve vault stored data
     try:
-        result = api_command(module, 'vault_retrieve', name, pwdargs)
+        result = module.ipa_command('vault_retrieve', name, pwdargs)
     except ipalib_errors.NotFound:
         return None
 
@@ -587,12 +581,9 @@ def get_stored_data(module, res_find, args):
 
 
 def main():
-    ansible_module = AnsibleModule(
+    ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # generalgroups
-            ipaadmin_principal=dict(type="str", default="admin"),
-            ipaadmin_password=dict(type="str", required=False, no_log=True),
-
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
 
@@ -663,9 +654,6 @@ def main():
     ansible_module._ansible_debug = True
 
     # general
-    ipaadmin_principal = module_params_get(ansible_module,
-                                           "ipaadmin_principal")
-    ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -732,17 +720,10 @@ def main():
 
     changed = False
     exit_args = {}
-    ccache_dir = None
-    ccache_name = None
-    try:
-        if not valid_creds(ansible_module, ipaadmin_principal):
-            ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
-                                                 ipaadmin_password)
-            # Need to set krb5 ccache name, due to context='ansible-freeipa'
-            if ccache_name is not None:
-                os.environ["KRB5CCNAME"] = ccache_name
 
-        api_connect(context='ansible-freeipa')
+    with ansible_module.ipa_connect(context='ansible-freeipa') as ccache_name:
+        if ccache_name is not None:
+            os.environ["KRB5CCNAME"] = ccache_name
 
         commands = []
 
@@ -970,7 +951,7 @@ def main():
         errors = []
         for name, command, args in commands:
             try:
-                result = api_command(ansible_module, command, name, args)
+                result = ansible_module.ipa_command(command, name, args)
 
                 if command == 'vault_archive':
                     changed = 'Archived data into' in result['summary']
@@ -1011,12 +992,6 @@ def main():
                                 command, member_type, member, failure))
         if len(errors) > 0:
             ansible_module.fail_json(msg=", ".join(errors))
-
-    except Exception as exception:
-        ansible_module.fail_json(msg=str(exception))
-
-    finally:
-        temp_kdestroy(ccache_dir, ccache_name)
 
     # Done
 

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -650,8 +650,6 @@ def main():
                             ['vault_public_key', 'vault_public_key_file']],
     )
 
-    ansible_module._ansible_debug = True
-
     # general
     names = ansible_module.params_get("name")
 

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -315,8 +315,7 @@ import os
 from base64 import b64decode
 from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import IPAAnsibleModule, \
-    gen_add_del_lists, compare_args_ipa, module_params_get, exit_raw_json, \
-    ipalib_errors
+    gen_add_del_lists, compare_args_ipa, exit_raw_json, ipalib_errors
 
 
 def find_vault(module, name, username, service, shared):
@@ -654,42 +653,40 @@ def main():
     ansible_module._ansible_debug = True
 
     # general
-    names = module_params_get(ansible_module, "name")
+    names = ansible_module.params_get("name")
 
     # present
-    description = module_params_get(ansible_module, "description")
+    description = ansible_module.params_get("description")
 
-    username = module_params_get(ansible_module, "username")
-    service = module_params_get(ansible_module, "service")
-    shared = module_params_get(ansible_module, "shared")
+    username = ansible_module.params_get("username")
+    service = ansible_module.params_get("service")
+    shared = ansible_module.params_get("shared")
 
-    users = module_params_get(ansible_module, "users")
-    groups = module_params_get(ansible_module, "groups")
-    services = module_params_get(ansible_module, "services")
-    owners = module_params_get(ansible_module, "owners")
-    ownergroups = module_params_get(ansible_module, "ownergroups")
-    ownerservices = module_params_get(ansible_module, "ownerservices")
+    users = ansible_module.params_get("users")
+    groups = ansible_module.params_get("groups")
+    services = ansible_module.params_get("services")
+    owners = ansible_module.params_get("owners")
+    ownergroups = ansible_module.params_get("ownergroups")
+    ownerservices = ansible_module.params_get("ownerservices")
 
-    vault_type = module_params_get(ansible_module, "vault_type")
-    salt = module_params_get(ansible_module, "vault_salt")
-    password = module_params_get(ansible_module, "vault_password")
-    password_file = module_params_get(ansible_module, "vault_password_file")
-    new_password = module_params_get(ansible_module, "new_password")
-    new_password_file = module_params_get(ansible_module, "new_password_file")
-    public_key = module_params_get(ansible_module, "vault_public_key")
-    public_key_file = module_params_get(ansible_module,
-                                        "vault_public_key_file")
-    private_key = module_params_get(ansible_module, "vault_private_key")
-    private_key_file = module_params_get(ansible_module,
-                                         "vault_private_key_file")
+    vault_type = ansible_module.params_get("vault_type")
+    salt = ansible_module.params_get("vault_salt")
+    password = ansible_module.params_get("vault_password")
+    password_file = ansible_module.params_get("vault_password_file")
+    new_password = ansible_module.params_get("new_password")
+    new_password_file = ansible_module.params_get("new_password_file")
+    public_key = ansible_module.params_get("vault_public_key")
+    public_key_file = ansible_module.params_get("vault_public_key_file")
+    private_key = ansible_module.params_get("vault_private_key")
+    private_key_file = ansible_module.params_get("vault_private_key_file")
 
-    vault_data = module_params_get(ansible_module, "vault_data")
+    vault_data = ansible_module.params_get("vault_data")
 
-    datafile_in = module_params_get(ansible_module, "datafile_in")
-    datafile_out = module_params_get(ansible_module, "datafile_out")
+    datafile_in = ansible_module.params_get("datafile_in")
+    datafile_out = ansible_module.params_get("datafile_out")
 
-    action = module_params_get(ansible_module, "action")
-    state = module_params_get(ansible_module, "state")
+    action = ansible_module.params_get("action")
+    state = ansible_module.params_get("state")
 
     # Check parameters
 


### PR DESCRIPTION
This new PR modifies `ipavault` and `ipaconfig` to use only the new IPAAnsibleModule class, and removes `_ansible_debug` from all modules, setting it in IPAAnsibleModule constructor.

Check individual commits for more information.